### PR TITLE
Dump the output of `yarn build`.

### DIFF
--- a/node-builder/bin/build
+++ b/node-builder/bin/build
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-yarn build
+yarn build > /dev/null
 yarn pack --filename dist/artifact.tar.gz > /dev/null
 echo artifact.tar.gz


### PR DESCRIPTION
The intent of the `bin/build` script is to only output the filename. All other output needs dumped.